### PR TITLE
fix: restarted kernal, llm now correctly summarizing articles content

### DIFF
--- a/LOD_API_PROJECT.ipynb
+++ b/LOD_API_PROJECT.ipynb
@@ -159,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 57,
    "id": "5eeb30fa-8fad-4001-a74b-ab3636742403",
    "metadata": {},
    "outputs": [


### PR DESCRIPTION
- fixed LLM api error by restarting kernals in jupytr
- syncing to github to show correct and successful prints of summarized articles
